### PR TITLE
Fix-typo

### DIFF
--- a/_posts/2016-09-06-Analysing-.NET-Memory-Dumps-with-CLR-MD.md
+++ b/_posts/2016-09-06-Analysing-.NET-Memory-Dumps-with-CLR-MD.md
@@ -22,11 +22,11 @@ This post explores some of the things you can achieve by instead using CLR MD, a
 
 This post isn't meant to serve as a *Getting Started* guide, there's already a great set of Tutorials [linked from project README](https://github.com/Microsoft/clrmd#tutorials) that serve that purpose:
 
-- [Getting Started](https://github.com/Microsoft/clrmd/blob/master/Documentation/GettingStarted.md) - A brief introduction to the API and how to create a CLRRuntime instance.
-- [The CLRRuntime Object](https://github.com/Microsoft/clrmd/blob/master/Documentation/ClrRuntime.md) - Basic operations like enumerating AppDomains, Threads, the Finalizer Queue, etc.
-- [Walking the Heap](https://github.com/Microsoft/clrmd/blob/master/Documentation/WalkingTheHeap.md) - Walking objects on the GC heap, working with types in CLR MD.
-- [Types and Fields in CLRMD](https://github.com/Microsoft/clrmd/blob/master/Documentation/TypesAndFields.md) - More information about dealing with types and fields in CLRMD.
-- [Machine Code in CLRMD](https://github.com/Microsoft/clrmd/blob/master/Documentation/MachineCode.md) - Getting access to the native code produced by the JIT or NGEN
+- [Getting Started](https://github.com/microsoft/clrmd/blob/master/doc/GettingStarted.md) - A brief introduction to the API and how to create a CLRRuntime instance.
+- [The CLRRuntime Object](https://github.com/microsoft/clrmd/blob/master/doc/ClrRuntime.md) - Basic operations like enumerating AppDomains, Threads, the Finalizer Queue, etc.
+- [Walking the Heap](https://github.com/microsoft/clrmd/blob/master/doc/WalkingTheHeap.md) - Walking objects on the GC heap, working with types in CLR MD.
+- [Types and Fields in CLRMD](https://github.com/microsoft/clrmd/blob/master/doc/TypesAndFields.md) - More information about dealing with types and fields in CLRMD.
+- [Machine Code in CLRMD](https://github.com/microsoft/clrmd/blob/master/doc/MachineCode.md) - Getting access to the native code produced by the JIT or NGEN
 
 However we will be looking at what else CLR MD allows you to achieve.
 


### PR DESCRIPTION
Links broken fixed in page: [2016-09-06-Analysing-.NET-Memory-Dumps-with-CLR-MD.md](https://mattwarren.org/2016/09/06/Analysing-.NET-Memory-Dumps-with-CLR-MD/)